### PR TITLE
Add player impact modelling pipeline

### DIFF
--- a/clustering_roles.py
+++ b/clustering_roles.py
@@ -1,0 +1,100 @@
+"""Role-aware clustering for batters and bowlers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class ClusteringResult:
+    labels: pd.Series
+    centroids: pd.DataFrame
+    feature_columns: List[str]
+    model: KMeans
+
+
+def _fit_kmeans(features: pd.DataFrame, n_clusters: int, random_state: int = 42) -> ClusteringResult:
+    scaler = StandardScaler()
+    clean_features = features.fillna(0)
+    effective_clusters = max(1, min(n_clusters, len(clean_features)))
+    scaled = scaler.fit_transform(clean_features)
+    model = KMeans(n_clusters=effective_clusters, random_state=random_state, n_init=20)
+    labels = model.fit_predict(scaled)
+    centroids = pd.DataFrame(
+        scaler.inverse_transform(model.cluster_centers_),
+        columns=features.columns,
+    )
+    return ClusteringResult(labels=pd.Series(labels, index=features.index), centroids=centroids, feature_columns=list(features.columns), model=model)
+
+
+def cluster_batters(batting_df: pd.DataFrame, n_clusters: int = 4) -> Tuple[pd.DataFrame, ClusteringResult]:
+    """Cluster batters into archetypes."""
+
+    feature_cols = ["batting_strike_rate", "batting_average", "boundary_percentage", "dot_percentage", "batting_index"]
+    available = batting_df.reindex(columns=feature_cols).fillna(0)
+    result = _fit_kmeans(available, n_clusters=n_clusters)
+
+    clustered = batting_df.copy()
+    clustered["batter_cluster"] = result.labels
+
+    return clustered, result
+
+
+def cluster_bowlers(bowling_df: pd.DataFrame, n_clusters: int = 4) -> Tuple[pd.DataFrame, ClusteringResult]:
+    """Cluster bowlers into archetypes."""
+
+    feature_cols = ["bowling_economy", "bowling_strike_rate", "wickets_per_match", "phase_efficacy", "bowling_index"]
+    available = bowling_df.reindex(columns=feature_cols).fillna(0)
+    result = _fit_kmeans(available, n_clusters=n_clusters)
+
+    clustered = bowling_df.copy()
+    clustered["bowler_cluster"] = result.labels
+
+    return clustered, result
+
+
+def label_batter_clusters(result: ClusteringResult) -> Dict[int, str]:
+    """Assign descriptive names to batter clusters based on centroids."""
+
+    centroids = result.centroids.copy()
+    labels = {}
+    for cluster_id, centroid in centroids.iterrows():
+        sr = centroid["batting_strike_rate"]
+        boundary = centroid["boundary_percentage"]
+        dot = centroid["dot_percentage"]
+        average = centroid["batting_average"]
+        if sr >= np.percentile(centroids["batting_strike_rate"], 75):
+            labels[cluster_id] = "Power Hitter"
+        elif dot >= np.percentile(centroids["dot_percentage"], 75):
+            labels[cluster_id] = "Anchor"
+        elif average >= np.percentile(centroids["batting_average"], 75):
+            labels[cluster_id] = "Accumulator"
+        else:
+            labels[cluster_id] = "Finisher"
+    return labels
+
+
+def label_bowler_clusters(result: ClusteringResult) -> Dict[int, str]:
+    """Assign descriptive names to bowler clusters based on centroids."""
+
+    centroids = result.centroids.copy()
+    labels = {}
+    for cluster_id, centroid in centroids.iterrows():
+        economy = centroid["bowling_economy"]
+        strike = centroid["bowling_strike_rate"]
+        wickets = centroid["wickets_per_match"]
+        phase = centroid["phase_efficacy"]
+        if phase >= np.percentile(centroids["phase_efficacy"], 75):
+            labels[cluster_id] = "Death Specialist"
+        elif wickets >= np.percentile(centroids["wickets_per_match"], 75):
+            labels[cluster_id] = "Strike Bowler"
+        elif economy <= np.percentile(centroids["bowling_economy"], 25):
+            labels[cluster_id] = "Powerplay Controller"
+        else:
+            labels[cluster_id] = "Middle Overs"
+    return labels

--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -1,0 +1,245 @@
+"""Data loading and preprocessing utilities for the IPL player impact project."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
+
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PreprocessingConfig:
+    """Configuration for preprocessing behaviour."""
+
+    phase_bins: Dict[str, range] = None
+
+    def __post_init__(self) -> None:
+        if self.phase_bins is None:
+            self.phase_bins = {
+                "Powerplay": range(1, 7),
+                "Middle": range(7, 16),
+                "Death": range(16, 21),
+            }
+
+
+COLUMN_ALIASES = {
+    "match_id": {"match_id", "Match_Id", "matchid"},
+    "season": {"season", "Season", "match_season"},
+    "date": {"date", "match_date", "start_date"},
+    "venue": {"venue", "stadium"},
+    "city": {"city", "match_city"},
+    "innings": {"innings", "inning"},
+    "over": {"over", "overs"},
+    "ball_in_over": {"ball", "ball_number", "ball_in_over"},
+    "batter": {"batter", "striker", "batsman"},
+    "non_striker": {"non_striker", "non-striker"},
+    "bowler": {"bowler"},
+    "batting_team": {"batting_team", "team_batting", "bat_team"},
+    "bowling_team": {"bowling_team", "team_bowling", "bowl_team"},
+    "runs_batter": {"runs_batter", "batsman_runs", "runs_off_bat", "runs_batsman"},
+    "runs_total": {"runs_total", "total_runs", "total"},
+    "runs_extras": {"runs_extras", "extras", "extra_runs"},
+    "extra_type": {"extra_type", "extras_type", "extra_kind"},
+    "player_out": {"player_out", "dismissed_player", "player_dismissed"},
+    "wicket_kind": {"wicket_kind", "dismissal_kind", "kind"},
+    "fielder": {"fielder", "fielders_involved"},
+    "is_wicket": {"is_wicket", "wicket"},
+    "win_team": {"match_won_by", "winner", "winning_team", "match_winner"},
+}
+
+
+def _select_first_available(df: pd.DataFrame, candidates: Iterable[str], default: Optional[str] = None) -> Optional[str]:
+    """Return the first column from candidates that exists in the frame."""
+
+    for candidate in candidates:
+        if candidate in df.columns:
+            return candidate
+    return default
+
+
+def load_data(file_path: str, **read_csv_kwargs) -> pd.DataFrame:
+    """Load the raw IPL ball-by-ball dataset."""
+
+    defaults = {"low_memory": False}
+    defaults.update(read_csv_kwargs)
+    logger.info("Loading dataset from %s", file_path)
+    df = pd.read_csv(file_path, **defaults)
+    if df.empty:
+        raise ValueError("Loaded dataframe is empty. Ensure the dataset is available via Git LFS.")
+    return df
+
+
+def _canonicalise_columns(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    rename_map = {}
+    for canonical, aliases in COLUMN_ALIASES.items():
+        if canonical in df.columns:
+            continue
+        selected = _select_first_available(df, aliases)
+        if selected:
+            rename_map[selected] = canonical
+    df = df.rename(columns=rename_map)
+    return df
+
+
+def _add_over_and_phase(df: pd.DataFrame, config: PreprocessingConfig) -> pd.DataFrame:
+    df = df.copy()
+
+    if "over" not in df.columns:
+        if "ball" in df.columns:
+            df["over"] = df["ball"].astype(str).str.split(".").str[0].astype(int)
+        else:
+            df["over"] = 0
+    else:
+        df["over"] = pd.to_numeric(df["over"], errors="coerce").fillna(0).astype(int)
+
+    if "ball_in_over" not in df.columns:
+        if "ball" in df.columns:
+            df["ball_in_over"] = df["ball"].astype(str).str.split(".").str[1].fillna("0").astype(int)
+        else:
+            df["ball_in_over"] = 0
+    else:
+        df["ball_in_over"] = pd.to_numeric(df["ball_in_over"], errors="coerce").fillna(0).astype(int)
+
+    def assign_phase(over: int) -> str:
+        for phase, rng in config.phase_bins.items():
+            if over in rng:
+                return phase
+        return "Other"
+
+    df["phase"] = df["over"].apply(assign_phase)
+    return df
+
+
+def _infer_boolean_columns(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    runs_total_col = _select_first_available(df, COLUMN_ALIASES["runs_total"], "runs_total")
+    runs_total = df.get(runs_total_col, 0)
+    df["is_dot_ball"] = runs_total == 0
+
+    wicket_flag_col = _select_first_available(df, COLUMN_ALIASES["is_wicket"], None)
+    if wicket_flag_col:
+        df["is_wicket"] = df[wicket_flag_col].astype(bool)
+    else:
+        df["is_wicket"] = df[_select_first_available(df, COLUMN_ALIASES["player_out"], "player_out")].notna()
+
+    return df
+
+
+def prepare_ball_by_ball(df: pd.DataFrame, config: Optional[PreprocessingConfig] = None) -> pd.DataFrame:
+    """Standardise column names and add derived features."""
+
+    if config is None:
+        config = PreprocessingConfig()
+
+    df = _canonicalise_columns(df)
+
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+
+    df = _add_over_and_phase(df, config)
+    df = _infer_boolean_columns(df)
+
+    for required in ("match_id", "batter", "bowler", "batting_team", "bowling_team"):
+        if required not in df.columns:
+            raise KeyError(f"Required column '{required}' not found after canonicalisation.")
+
+    return df
+
+
+def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate ball-level data to player-match level batting and bowling features."""
+
+    df = df.copy()
+
+    runs_batter_col = _select_first_available(df, COLUMN_ALIASES["runs_batter"], "runs_batter")
+    runs_total_col = _select_first_available(df, COLUMN_ALIASES["runs_total"], "runs_total")
+    player_out_col = _select_first_available(df, COLUMN_ALIASES["player_out"], "player_out")
+    wicket_kind_col = _select_first_available(df, COLUMN_ALIASES["wicket_kind"], "wicket_kind")
+
+    df["runs_batter"] = pd.to_numeric(df.get(runs_batter_col, 0), errors="coerce").fillna(0)
+    df["runs_total"] = pd.to_numeric(df.get(runs_total_col, 0), errors="coerce").fillna(0)
+
+    df["is_boundary"] = df["runs_batter"].isin([4, 6])
+    df["is_six"] = df["runs_batter"] == 6
+    df["is_four"] = df["runs_batter"] == 4
+
+    df["batter_dismissed"] = df[player_out_col].fillna("__none__") == df["batter"]
+
+    dismissal_exclusions = {"run out", "retired hurt", "retired out", "obstructing the field"}
+    wicket_kind = df.get(wicket_kind_col, "").astype(str).str.lower()
+    df["is_bowler_wicket"] = df["batter_dismissed"] & ~wicket_kind.fillna("").isin(dismissal_exclusions)
+
+    df["phase_runs_tuple"] = list(zip(df["phase"], df["runs_total"]))
+    df["phase_balls_tuple"] = list(zip(df["phase"], df["runs_total"]))
+
+    def _phase_sum(values):
+        store: Dict[str, float] = {}
+        for phase, val in values:
+            if pd.isna(phase):
+                continue
+            store[phase] = store.get(phase, 0.0) + float(val)
+        return store
+
+    batter_group_cols = ["match_id", "season", "batting_team", "batter"]
+    batting_agg = (
+        df.groupby(batter_group_cols)
+        .agg(
+            runs_scored=("runs_batter", "sum"),
+            balls_faced=("runs_batter", "count"),
+            fours=("is_four", "sum"),
+            sixes=("is_six", "sum"),
+            boundaries=("is_boundary", "sum"),
+            dot_balls=("is_dot_ball", "sum"),
+            dismissals=("batter_dismissed", "sum"),
+            phases=("phase_runs_tuple", lambda s: _phase_sum([(phase, 1) for phase, _ in s] if len(s) else [])),
+        )
+        .reset_index()
+    )
+    batting_agg = batting_agg.rename(columns={"batting_team": "team", "batter": "player"})
+
+    bowler_group_cols = ["match_id", "season", "bowling_team", "bowler"]
+    bowling_agg = (
+        df.groupby(bowler_group_cols)
+        .agg(
+            runs_conceded=("runs_total", "sum"),
+            balls_bowled=("runs_total", "count"),
+            wickets=("is_bowler_wicket", "sum"),
+            dot_balls_bowling=("is_dot_ball", "sum"),
+            phase_runs=("phase_runs_tuple", _phase_sum),
+            phase_balls=("phase_balls_tuple", lambda s: _phase_sum([(phase, 1) for phase, _ in s] if len(s) else [])),
+        )
+        .reset_index()
+    )
+
+    if "phase" in df.columns:
+        phase_stats = (
+            df.groupby(["bowler", "phase"])
+            .agg(phase_runs=("runs_total", "sum"), phase_balls=("runs_total", "count"))
+            .reset_index()
+        )
+    else:
+        phase_stats = pd.DataFrame(columns=["bowler", "phase", "phase_runs", "phase_balls"])
+
+    bowling_agg = bowling_agg.rename(columns={"bowling_team": "team", "bowler": "player"})
+
+    player_stats = pd.merge(batting_agg, bowling_agg, on=["match_id", "season", "team", "player"], how="outer", indicator=True)
+
+    for tmp_col in ["phase_runs_tuple_x", "phase_runs_tuple_y", "phase_balls_tuple"]:
+        if tmp_col in player_stats.columns:
+            player_stats = player_stats.drop(columns=tmp_col)
+
+    win_col = _select_first_available(df, COLUMN_ALIASES["win_team"], None)
+    if win_col:
+        match_winners = df[["match_id", win_col]].drop_duplicates().rename(columns={win_col: "winning_team"})
+        player_stats = player_stats.merge(match_winners, on="match_id", how="left")
+        player_stats["team_won"] = (player_stats["team"] == player_stats["winning_team"]).astype(int)
+    else:
+        player_stats["winning_team"] = None
+        player_stats["team_won"] = 0
+
+    return player_stats, phase_stats

--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -1,0 +1,186 @@
+"""Feature engineering utilities for player impact modelling."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def _safe_divide(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
+    result = numerator.copy().astype(float)
+    denom = denominator.replace({0: np.nan})
+    result = result.divide(denom)
+    return result.fillna(0.0)
+
+
+def compute_batting_metrics(player_stats: pd.DataFrame) -> pd.DataFrame:
+    """Derive batting metrics and composite batting index."""
+
+    batting = player_stats.copy()
+    batting["balls_faced"] = batting["balls_faced"].fillna(0)
+    batting["runs_scored"] = batting["runs_scored"].fillna(0)
+    batting["dismissals"] = batting["dismissals"].fillna(0)
+    batting["boundaries"] = batting["boundaries"].fillna(0)
+    batting["dot_balls"] = batting["dot_balls"].fillna(0)
+
+    batting["batting_strike_rate"] = _safe_divide(batting["runs_scored"] * 100, batting["balls_faced"])
+    batting["batting_average"] = _safe_divide(batting["runs_scored"], batting["dismissals"].replace({0: np.nan}))
+    batting["boundary_percentage"] = _safe_divide(batting["boundaries"] * 100, batting["balls_faced"])
+    batting["dot_percentage"] = _safe_divide(batting["dot_balls"] * 100, batting["balls_faced"])
+    batting["batting_contribution"] = batting["runs_scored"]
+
+    return batting
+
+
+def compute_bowling_metrics(player_stats: pd.DataFrame, league_phase_summary: pd.DataFrame) -> pd.DataFrame:
+    """Derive bowling metrics including phase efficacy."""
+
+    bowling = player_stats.copy()
+    bowling["balls_bowled"] = bowling["balls_bowled"].fillna(0)
+    bowling["runs_conceded"] = bowling["runs_conceded"].fillna(0)
+    bowling["wickets"] = bowling["wickets"].fillna(0)
+
+    bowling["overs_bowled"] = bowling["balls_bowled"] / 6.0
+    bowling["bowling_economy"] = _safe_divide(bowling["runs_conceded"], bowling["overs_bowled"].replace({0: np.nan}))
+    bowling["bowling_strike_rate"] = _safe_divide(bowling["balls_bowled"], bowling["wickets"].replace({0: np.nan}))
+    bowling["wickets_per_match"] = bowling["wickets"]
+
+    if league_phase_summary is not None and not league_phase_summary.empty:
+        league_phase_summary = league_phase_summary.copy()
+        league_phase_summary["phase_run_rate"] = _safe_divide(
+            league_phase_summary["phase_runs"] * 6,
+            league_phase_summary["phase_balls"],
+        )
+        league_phase = league_phase_summary.groupby("phase")["phase_run_rate"].mean().to_dict()
+
+        def compute_phase_efficacy(row: pd.Series) -> float:
+            phase_dict = row.get("phase_runs", {})
+            ball_dict = row.get("phase_balls", {})
+            if not isinstance(phase_dict, dict) or not phase_dict:
+                return 0.0
+            weighted_diff = 0.0
+            total_balls = 0.0
+            for phase, runs in phase_dict.items():
+                balls = ball_dict.get(phase, 0.0)
+                if balls == 0:
+                    continue
+                league_rr = league_phase.get(phase, 0.0)
+                player_rr = (runs * 6) / balls
+                weighted_diff += (league_rr - player_rr) * balls
+                total_balls += balls
+            if total_balls == 0:
+                return 0.0
+            return weighted_diff / total_balls
+
+        bowling["phase_efficacy"] = bowling.apply(compute_phase_efficacy, axis=1)
+    else:
+        bowling["phase_efficacy"] = 0.0
+
+    return bowling
+
+
+def compute_composite_indices(
+    batting_features: pd.DataFrame,
+    bowling_features: pd.DataFrame,
+    target_col: str = "team_won",
+    weight_method: str = "correlation",
+) -> pd.DataFrame:
+    """Combine batting and bowling metrics with learned or correlation based weights."""
+
+    features = batting_features.merge(
+        bowling_features,
+        on=["match_id", "season", "team", "player", target_col, "winning_team"],
+        how="outer",
+        suffixes=("_bat", "_bowl"),
+    )
+
+    metric_columns = [
+        "batting_strike_rate",
+        "batting_average",
+        "boundary_percentage",
+        "dot_percentage",
+        "bowling_economy",
+        "bowling_strike_rate",
+        "wickets_per_match",
+        "phase_efficacy",
+    ]
+
+    for column in metric_columns:
+        if column not in features.columns:
+            features[column] = 0.0
+    features = features.fillna(0)
+
+    if weight_method == "correlation" and target_col in features.columns:
+        correlations = {}
+        target = features[target_col]
+        for column in metric_columns:
+            if features[column].std(ddof=0) == 0 or target.std(ddof=0) == 0:
+                correlations[column] = 0.0
+            else:
+                corr = features[column].corr(target)
+                correlations[column] = 0.0 if pd.isna(corr) else corr
+        weights = np.array([max(correlations[col], 0) for col in metric_columns])
+    else:
+        weights = np.ones(len(metric_columns))
+
+    if weights.sum() == 0:
+        weights = np.ones(len(weights))
+    normalized_weights = weights / weights.sum()
+
+    batting_metrics = ["batting_strike_rate", "batting_average", "boundary_percentage", "dot_percentage"]
+    bowling_metrics = ["bowling_economy", "bowling_strike_rate", "wickets_per_match", "phase_efficacy"]
+
+    features["batting_index"] = features[batting_metrics].mul(normalized_weights[:4], axis=1).sum(axis=1)
+    features["bowling_index"] = features[bowling_metrics].mul(normalized_weights[4:], axis=1).sum(axis=1)
+    features["overall_index"] = features[["batting_index", "bowling_index"]].sum(axis=1)
+
+    return features, metric_columns
+
+
+def build_model_matrix(features: pd.DataFrame, metric_columns: Iterable[str]) -> Tuple[pd.DataFrame, List[str]]:
+    """Construct modelling matrix with engineered features and target column."""
+
+    modelling_columns = list(metric_columns) + [
+        "batting_index",
+        "bowling_index",
+        "overall_index",
+        "runs_scored",
+        "balls_faced",
+        "wickets",
+        "overs_bowled",
+    ]
+
+    available_columns = [col for col in modelling_columns if col in features.columns]
+    model_df = features[["match_id", "player", "team", "season", "team_won"] + available_columns].copy()
+    model_df = model_df.fillna(0)
+
+    feature_cols = [col for col in available_columns if col not in {"team_won"}]
+    return model_df, feature_cols
+
+
+def aggregate_player_ratings(model_df: pd.DataFrame, shap_weights: Dict[str, float]) -> pd.DataFrame:
+    """Aggregate player impact ratings using SHAP-derived weights."""
+
+    rating_weights = pd.Series(shap_weights)
+    rating_weights = rating_weights / rating_weights.sum()
+
+    feature_cols = [col for col in rating_weights.index if col in model_df.columns]
+    weighted_scores = model_df[feature_cols].mul(rating_weights[feature_cols], axis=1).sum(axis=1)
+
+    player_ratings = (
+        model_df.assign(impact_score=weighted_scores)
+        .groupby(["player", "team", "season"], as_index=False)
+        .agg(impact_score=("impact_score", "mean"),
+             batting_index=("batting_index", "mean"),
+             bowling_index=("bowling_index", "mean"))
+    )
+
+    min_score = player_ratings["impact_score"].min()
+    max_score = player_ratings["impact_score"].max()
+    if max_score - min_score > 0:
+        player_ratings["impact_rating"] = 100 * (player_ratings["impact_score"] - min_score) / (max_score - min_score)
+    else:
+        player_ratings["impact_rating"] = 50
+
+    return player_ratings

--- a/main.py
+++ b/main.py
@@ -1,0 +1,255 @@
+"""Main orchestration script for the IPL player impact project."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from typing import Dict, List
+
+import pandas as pd
+
+from clustering_roles import (
+    cluster_batters,
+    cluster_bowlers,
+    label_batter_clusters,
+    label_bowler_clusters,
+)
+from data_preprocessing import (
+    PreprocessingConfig,
+    aggregate_player_match_stats,
+    load_data,
+    prepare_ball_by_ball,
+)
+from feature_engineering import (
+    aggregate_player_ratings,
+    build_model_matrix,
+    compute_batting_metrics,
+    compute_bowling_metrics,
+    compute_composite_indices,
+)
+from model_training import generate_classification_report, train_impact_model
+from shap_analysis import compute_shap_values, summarise_shap_importance
+from visualization import plot_cluster_scatter, plot_shap_summary
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _determine_primary_role(row: pd.Series, batting_roles: Dict[int, str], bowling_roles: Dict[int, str]) -> str:
+    has_batting = row.get("balls_faced", 0) > 30
+    has_bowling = row.get("balls_bowled", 0) > 18
+    batter_label = batting_roles.get(row.get("batter_cluster")) if row.get("batter_cluster") is not None else None
+    bowler_label = bowling_roles.get(row.get("bowler_cluster")) if row.get("bowler_cluster") is not None else None
+
+    if has_batting and has_bowling:
+        return "Allrounder"
+    if has_batting and batter_label:
+        return batter_label
+    if has_bowling and bowler_label:
+        return bowler_label
+    return batter_label or bowler_label or "Specialist"
+
+
+def select_best_xi(player_profiles: pd.DataFrame) -> pd.DataFrame:
+    """Select a balanced Best XI using impact ratings and role information."""
+
+    selected_players = []
+
+    def select_players(df: pd.DataFrame, count: int) -> List[str]:
+        chosen = []
+        for _, row in df.sort_values("impact_rating", ascending=False).iterrows():
+            if row["player"] in selected_players:
+                continue
+            selected_players.append(row["player"])
+            chosen.append(row["player"])
+            if len(chosen) == count:
+                break
+        return chosen
+
+    batting_roles = {"Power Hitter", "Anchor", "Accumulator", "Finisher"}
+    bowl_roles = {"Death Specialist", "Strike Bowler", "Powerplay Controller", "Middle Overs"}
+
+    batters = player_profiles[player_profiles["primary_role"].isin(batting_roles)]
+    select_players(batters, min(5, len(batters)))
+
+    allrounders = player_profiles[player_profiles["primary_role"] == "Allrounder"]
+    select_players(allrounders, min(2, len(allrounders)))
+
+    bowlers = player_profiles[player_profiles["primary_role"].isin(bowl_roles)]
+    select_players(bowlers, 11 - len(selected_players))
+
+    if len(selected_players) < 11:
+        remaining = player_profiles[~player_profiles["player"].isin(selected_players)]
+        select_players(remaining, 11 - len(selected_players))
+
+    return player_profiles[player_profiles["player"].isin(selected_players)].sort_values(
+        "impact_rating", ascending=False
+    )
+
+
+def main(data_path: str) -> Dict[str, object]:
+    logger.info("Starting pipeline with data path: %s", data_path)
+    raw_df = load_data(data_path)
+    processed_df = prepare_ball_by_ball(raw_df, PreprocessingConfig())
+
+    player_stats, phase_stats = aggregate_player_match_stats(processed_df)
+
+    batting_metrics = compute_batting_metrics(player_stats)
+    bowling_metrics = compute_bowling_metrics(player_stats, phase_stats)
+
+    features, metric_columns = compute_composite_indices(batting_metrics, bowling_metrics)
+    model_df, feature_cols = build_model_matrix(features, metric_columns)
+
+    logger.info("Training model with %d samples and %d features", len(model_df), len(feature_cols))
+    artifacts = train_impact_model(model_df, feature_cols)
+
+    shap_frame, shap_sample = compute_shap_values(artifacts.model, artifacts.X_train[feature_cols])
+    shap_summary = summarise_shap_importance(shap_frame)
+    shap_weights = dict(zip(shap_summary["feature"], shap_summary["mean_abs_shap"]))
+
+    if not shap_weights:
+        shap_weights = {col: 1.0 for col in feature_cols}
+
+    player_ratings = aggregate_player_ratings(model_df, shap_weights)
+
+    batter_base = batting_metrics[[
+        "player",
+        "team",
+        "balls_faced",
+        "batting_strike_rate",
+        "batting_average",
+        "boundary_percentage",
+        "dot_percentage",
+        "batting_index",
+    ]]
+    batter_clustered, batter_result = cluster_batters(batter_base)
+    batter_labels = label_batter_clusters(batter_result)
+    batter_clustered["batter_role"] = batter_clustered["batter_cluster"].map(batter_labels)
+
+    bowler_base = bowling_metrics[[
+        "player",
+        "team",
+        "balls_bowled",
+        "bowling_economy",
+        "bowling_strike_rate",
+        "wickets_per_match",
+        "phase_efficacy",
+        "bowling_index",
+    ]]
+    bowler_clustered, bowler_result = cluster_bowlers(bowler_base)
+    bowler_labels = label_bowler_clusters(bowler_result)
+    bowler_clustered["bowler_role"] = bowler_clustered["bowler_cluster"].map(bowler_labels)
+
+    batter_mode = batter_clustered.groupby("player")["batter_cluster"].agg(lambda s: s.mode().iloc[0] if not s.mode().empty else s.iloc[0])
+    bowler_mode = bowler_clustered.groupby("player")["bowler_cluster"].agg(lambda s: s.mode().iloc[0] if not s.mode().empty else s.iloc[0])
+
+    volume_stats = (
+        features[["player", "balls_faced", "balls_bowled"]]
+        .fillna(0)
+        .groupby("player", as_index=False)
+        .sum()
+    )
+
+    player_profiles = player_ratings.merge(
+        volume_stats,
+        on="player",
+        how="left",
+    ).merge(
+        batter_mode.rename("batter_cluster"),
+        on="player",
+        how="left",
+    ).merge(
+        bowler_mode.rename("bowler_cluster"),
+        on="player",
+        how="left",
+    )
+
+    player_profiles["balls_faced"] = player_profiles["balls_faced"].fillna(0)
+    player_profiles["balls_bowled"] = player_profiles["balls_bowled"].fillna(0)
+
+    player_profiles = (
+        player_profiles.sort_values("impact_rating", ascending=False)
+        .drop_duplicates("player")
+        .reset_index(drop=True)
+    )
+
+    player_profiles["batter_role"] = player_profiles["batter_cluster"].map(batter_labels)
+    player_profiles["bowler_role"] = player_profiles["bowler_cluster"].map(bowler_labels)
+
+    player_profiles["primary_role"] = player_profiles.apply(
+        _determine_primary_role,
+        axis=1,
+        batting_roles=batter_labels,
+        bowling_roles=bowler_labels,
+    )
+
+    best_xi = select_best_xi(player_profiles)
+
+    shap_plot_path = plot_shap_summary(shap_frame, shap_sample)
+
+    batter_cluster_plot = plot_cluster_scatter(
+        batter_clustered,
+        x_col="batting_strike_rate",
+        y_col="boundary_percentage",
+        cluster_col="batter_role",
+        title="Batter Archetypes",
+        output_filename="batter_clusters.png",
+    )
+
+    bowler_cluster_plot = plot_cluster_scatter(
+        bowler_clustered,
+        x_col="bowling_economy",
+        y_col="bowling_strike_rate",
+        cluster_col="bowler_role",
+        title="Bowler Archetypes",
+        output_filename="bowler_clusters.png",
+    )
+
+    report = generate_classification_report(artifacts)
+
+    outputs = {
+        "model_metrics": artifacts.metrics,
+        "classification_report": report,
+        "shap_summary": shap_summary,
+        "player_ratings": player_ratings.sort_values("impact_rating", ascending=False).head(25),
+        "best_xi": best_xi,
+        "plots": {
+            "shap_summary": shap_plot_path,
+            "batter_clusters": batter_cluster_plot,
+            "bowler_clusters": bowler_cluster_plot,
+        },
+        "cluster_labels": {
+            "batters": batter_labels,
+            "bowlers": bowler_labels,
+        },
+    }
+
+    logger.info("Pipeline complete")
+    return outputs
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Run the IPL player impact pipeline.")
+    parser.add_argument("data_path", nargs="?", default="IPL.csv", help="Path to the IPL ball-by-ball CSV file")
+    parser.add_argument("--export-json", dest="export_json", default=None, help="Optional path to export summary JSON")
+    args = parser.parse_args()
+
+    outputs = main(args.data_path)
+
+    if args.export_json:
+        serialisable = {
+            "model_metrics": outputs["model_metrics"],
+            "cluster_labels": outputs["cluster_labels"],
+            "plots": outputs["plots"],
+        }
+        with open(args.export_json, "w", encoding="utf-8") as fp:
+            json.dump(serialisable, fp, indent=2)
+        logger.info("Exported summary JSON to %s", args.export_json)
+
+    print("Model metrics:\n", outputs["model_metrics"])
+    print("Best XI:\n", outputs["best_xi"])  # type: ignore[truthy-bool]
+
+
+if __name__ == "__main__":
+    cli()

--- a/model_training.py
+++ b/model_training.py
@@ -1,0 +1,85 @@
+"""Model training utilities for player impact prediction."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import accuracy_score, classification_report, roc_auc_score
+from sklearn.model_selection import train_test_split
+from xgboost import XGBClassifier
+
+
+@dataclass
+class ModelArtifacts:
+    model: XGBClassifier
+    feature_cols: List[str]
+    X_train: pd.DataFrame
+    X_test: pd.DataFrame
+    y_train: pd.Series
+    y_test: pd.Series
+    metrics: Dict[str, float]
+    predictions: np.ndarray
+    probabilities: np.ndarray
+
+
+def train_impact_model(
+    data: pd.DataFrame,
+    feature_cols: List[str],
+    target_col: str = "team_won",
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> ModelArtifacts:
+    """Train an XGBoost model for player impact prediction."""
+
+    X = data[feature_cols]
+    y = data[target_col]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y if y.nunique() > 1 else None
+    )
+
+    model = XGBClassifier(
+        n_estimators=300,
+        max_depth=4,
+        learning_rate=0.05,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        reg_lambda=1.0,
+        random_state=random_state,
+        objective="binary:logistic",
+        eval_metric="auc",
+        tree_method="hist",
+        enable_categorical=False,
+    )
+
+    model.fit(X_train, y_train)
+
+    proba = model.predict_proba(X_test)[:, 1]
+    preds = (proba >= 0.5).astype(int)
+
+    metrics = {
+        "accuracy": accuracy_score(y_test, preds) if y_test.nunique() > 1 else float("nan"),
+        "roc_auc": roc_auc_score(y_test, proba) if y_test.nunique() > 1 else float("nan"),
+    }
+
+    return ModelArtifacts(
+        model=model,
+        feature_cols=feature_cols,
+        X_train=X_train,
+        X_test=X_test,
+        y_train=y_train,
+        y_test=y_test,
+        metrics=metrics,
+        predictions=preds,
+        probabilities=proba,
+    )
+
+
+def generate_classification_report(artifacts: ModelArtifacts) -> str:
+    """Generate a detailed classification report."""
+
+    if artifacts.y_test.nunique() <= 1:
+        return "Insufficient class variance in test labels for classification report."
+    return classification_report(artifacts.y_test, artifacts.predictions, digits=3)

--- a/shap_analysis.py
+++ b/shap_analysis.py
@@ -1,0 +1,49 @@
+"""SHAP explainability utilities for player impact modelling."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import pandas as pd
+import shap
+
+
+def compute_shap_values(
+    model,
+    X: pd.DataFrame,
+    sample_size: int = 2000,
+    random_state: int = 42,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Compute SHAP values for a fitted tree-based model."""
+
+    if len(X) == 0:
+        raise ValueError("Input feature matrix is empty. Cannot compute SHAP values.")
+
+    if sample_size and len(X) > sample_size:
+        X_sample = X.sample(sample_size, random_state=random_state)
+    else:
+        X_sample = X
+
+    explainer = shap.TreeExplainer(model)
+    shap_values = explainer.shap_values(X_sample)
+
+    if isinstance(shap_values, list):
+        shap_array = shap_values[1] if len(shap_values) > 1 else shap_values[0]
+    else:
+        shap_array = shap_values
+
+    shap_frame = pd.DataFrame(shap_array, columns=X_sample.columns, index=X_sample.index)
+    return shap_frame, X_sample
+
+
+def summarise_shap_importance(shap_frame: pd.DataFrame) -> pd.DataFrame:
+    """Summarise feature importance using mean absolute SHAP values."""
+
+    summary = (
+        shap_frame.abs()
+        .mean()
+        .sort_values(ascending=False)
+        .rename("mean_abs_shap")
+        .reset_index()
+        .rename(columns={"index": "feature"})
+    )
+    return summary

--- a/visualization.py
+++ b/visualization.py
@@ -1,0 +1,56 @@
+"""Plotting utilities for player impact project."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+import shap
+
+
+OUTPUT_DIR = "outputs"
+
+
+def _ensure_output_dir(path: str = OUTPUT_DIR) -> str:
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def plot_shap_summary(shap_values, features: pd.DataFrame, output_filename: str = "shap_summary.png") -> str:
+    """Create and save a SHAP summary plot."""
+
+    output_dir = _ensure_output_dir()
+    output_path = os.path.join(output_dir, output_filename)
+
+    plt.figure(figsize=(10, 6))
+    values = shap_values.values if hasattr(shap_values, "values") else shap_values
+    shap.summary_plot(values, features, show=False)
+    plt.tight_layout()
+    plt.savefig(output_path, bbox_inches="tight")
+    plt.close()
+    return output_path
+
+
+def plot_cluster_scatter(
+    data: pd.DataFrame,
+    x_col: str,
+    y_col: str,
+    cluster_col: str,
+    title: str,
+    output_filename: str,
+    hue_order: Optional[list] = None,
+) -> str:
+    """Plot clusters in two-dimensional space."""
+
+    output_dir = _ensure_output_dir()
+    output_path = os.path.join(output_dir, output_filename)
+
+    plt.figure(figsize=(8, 6))
+    sns.scatterplot(data=data, x=x_col, y=y_col, hue=cluster_col, palette="deep", hue_order=hue_order)
+    plt.title(title)
+    plt.tight_layout()
+    plt.savefig(output_path, bbox_inches="tight")
+    plt.close()
+    return output_path


### PR DESCRIPTION
## Summary
- add preprocessing utilities to standardise ball-by-ball data and aggregate player match statistics
- implement feature engineering, modelling, SHAP analysis, clustering, and plotting modules for player impact
- build a main orchestration script that trains the model, generates impact ratings, clusters roles, and outputs a recommended Best XI

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68e41788d49883238160735cb37950e6