### PR TITLE
Add Streamlit dashboard for IPL insights

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, Iterable, Optional
 
+import numpy as np
 import pandas as pd
 
 
@@ -34,20 +35,20 @@ COLUMN_ALIASES = {
     "city": {"city", "match_city"},
     "innings": {"innings", "inning"},
     "over": {"over", "overs"},
-    "ball_in_over": {"ball", "ball_number", "ball_in_over"},
+    "ball_in_over": {"ball", "ball_number", "ball_in_over", "ball_no"},
     "batter": {"batter", "striker", "batsman"},
     "non_striker": {"non_striker", "non-striker"},
     "bowler": {"bowler"},
     "batting_team": {"batting_team", "team_batting", "bat_team"},
     "bowling_team": {"bowling_team", "team_bowling", "bowl_team"},
-    "runs_batter": {"runs_batter", "batsman_runs", "runs_off_bat", "runs_batsman"},
+    "runs_batter": {"runs_batter", "batsman_runs", "runs_off_bat", "runs_batsman", "batter_runs"},
     "runs_total": {"runs_total", "total_runs", "total"},
     "runs_extras": {"runs_extras", "extras", "extra_runs"},
     "extra_type": {"extra_type", "extras_type", "extra_kind"},
     "player_out": {"player_out", "dismissed_player", "player_dismissed"},
     "wicket_kind": {"wicket_kind", "dismissal_kind", "kind"},
-    "fielder": {"fielder", "fielders_involved"},
-    "is_wicket": {"is_wicket", "wicket"},
+    "fielder": {"fielder", "fielders_involved", "fielders"},
+    "is_wicket": {"is_wicket", "wicket", "striker_out"},
     "win_team": {"match_won_by", "winner", "winning_team", "match_winner"},
 }
 
@@ -68,6 +69,10 @@ def load_data(file_path: str, **read_csv_kwargs) -> pd.DataFrame:
     defaults.update(read_csv_kwargs)
     logger.info("Loading dataset from %s", file_path)
     df = pd.read_csv(file_path, **defaults)
+    unnamed_columns = [col for col in df.columns if col.startswith("Unnamed")]
+    if unnamed_columns:
+        logger.debug("Dropping unnamed columns: %s", unnamed_columns)
+        df = df.drop(columns=unnamed_columns)
     if df.empty:
         raise ValueError("Loaded dataframe is empty. Ensure the dataset is available via Git LFS.")
     return df
@@ -89,21 +94,56 @@ def _canonicalise_columns(df: pd.DataFrame) -> pd.DataFrame:
 def _add_over_and_phase(df: pd.DataFrame, config: PreprocessingConfig) -> pd.DataFrame:
     df = df.copy()
 
-    if "over" not in df.columns:
-        if "ball" in df.columns:
-            df["over"] = df["ball"].astype(str).str.split(".").str[0].astype(int)
-        else:
-            df["over"] = 0
-    else:
-        df["over"] = pd.to_numeric(df["over"], errors="coerce").fillna(0).astype(int)
+    existing_over = (
+        pd.to_numeric(df["over"], errors="coerce") if "over" in df.columns else pd.Series(np.nan, index=df.index)
+    )
+    existing_ball_in_over = (
+        pd.to_numeric(df["ball_in_over"], errors="coerce")
+        if "ball_in_over" in df.columns
+        else pd.Series(np.nan, index=df.index)
+    )
 
-    if "ball_in_over" not in df.columns:
-        if "ball" in df.columns:
-            df["ball_in_over"] = df["ball"].astype(str).str.split(".").str[1].fillna("0").astype(int)
-        else:
-            df["ball_in_over"] = 0
+    derived_over = pd.Series(np.nan, index=df.index)
+    derived_ball = pd.Series(np.nan, index=df.index)
+
+    if "ball_no" in df.columns:
+        ball_no = pd.to_numeric(df["ball_no"], errors="coerce")
+        if ball_no.notna().any():
+            floor = np.floor(ball_no)
+            derived_over = floor + 1
+            derived_ball = (ball_no - floor) * 10
+    elif "ball" in df.columns:
+        ball_str = df["ball"].astype(str)
+        if ball_str.str.contains(".").any():
+            derived_over = pd.to_numeric(ball_str.str.split(".").str[0], errors="coerce")
+            derived_ball = pd.to_numeric(ball_str.str.split(".").str[1], errors="coerce")
+
+    if derived_over.notna().any():
+        over_series = pd.to_numeric(derived_over, errors="coerce")
+        over_series = over_series.fillna(existing_over)
     else:
-        df["ball_in_over"] = pd.to_numeric(df["ball_in_over"], errors="coerce").fillna(0).astype(int)
+        over_series = existing_over
+
+    if over_series.isna().all() and "over" not in df.columns:
+        over_series = pd.Series(0, index=df.index, dtype="int64")
+    else:
+        over_series = over_series.fillna(0)
+    df["over"] = over_series.astype(int).clip(lower=0)
+
+    if derived_ball.notna().any():
+        ball_series = pd.to_numeric(derived_ball, errors="coerce").round().astype("Int64")
+        if "ball" in df.columns:
+            fallback_ball = pd.to_numeric(df["ball"], errors="coerce")
+            ball_series = ball_series.where(ball_series.notna() & (ball_series > 0), fallback_ball)
+        ball_series = ball_series.fillna(existing_ball_in_over)
+    else:
+        if "ball" in df.columns:
+            ball_series = pd.to_numeric(df["ball"], errors="coerce")
+        else:
+            ball_series = existing_ball_in_over
+
+    ball_series = ball_series.fillna(0)
+    df["ball_in_over"] = ball_series.astype(int).clip(lower=0)
 
     def assign_phase(over: int) -> str:
         for phase, rng in config.phase_bins.items():
@@ -118,12 +158,20 @@ def _add_over_and_phase(df: pd.DataFrame, config: PreprocessingConfig) -> pd.Dat
 def _infer_boolean_columns(df: pd.DataFrame) -> pd.DataFrame:
     df = df.copy()
     runs_total_col = _select_first_available(df, COLUMN_ALIASES["runs_total"], "runs_total")
-    runs_total = df.get(runs_total_col, 0)
-    df["is_dot_ball"] = runs_total == 0
+    runs_total = pd.to_numeric(df.get(runs_total_col, 0), errors="coerce").fillna(0)
+
+    valid_col = "valid_ball" if "valid_ball" in df.columns else None
+    if valid_col:
+        valid_series = pd.to_numeric(df[valid_col], errors="coerce").fillna(0).astype(int)
+    else:
+        valid_series = pd.Series(1, index=df.index, dtype=int)
+    df["valid_ball"] = valid_series
+
+    df["is_dot_ball"] = (runs_total == 0) & df["valid_ball"].astype(bool)
 
     wicket_flag_col = _select_first_available(df, COLUMN_ALIASES["is_wicket"], None)
     if wicket_flag_col:
-        df["is_wicket"] = df[wicket_flag_col].astype(bool)
+        df["is_wicket"] = df[wicket_flag_col].fillna(False).astype(bool)
     else:
         df["is_wicket"] = df[_select_first_available(df, COLUMN_ALIASES["player_out"], "player_out")].notna()
 
@@ -163,6 +211,7 @@ def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
 
     df["runs_batter"] = pd.to_numeric(df.get(runs_batter_col, 0), errors="coerce").fillna(0)
     df["runs_total"] = pd.to_numeric(df.get(runs_total_col, 0), errors="coerce").fillna(0)
+    df["valid_ball"] = pd.to_numeric(df.get("valid_ball", 1), errors="coerce").fillna(0).astype(int)
 
     df["is_boundary"] = df["runs_batter"].isin([4, 6])
     df["is_six"] = df["runs_batter"] == 6
@@ -174,8 +223,10 @@ def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
     wicket_kind = df.get(wicket_kind_col, "").astype(str).str.lower()
     df["is_bowler_wicket"] = df["batter_dismissed"] & ~wicket_kind.fillna("").isin(dismissal_exclusions)
 
+    df["dot_ball_flag"] = df["is_dot_ball"] & df["valid_ball"].astype(bool)
+
     df["phase_runs_tuple"] = list(zip(df["phase"], df["runs_total"]))
-    df["phase_balls_tuple"] = list(zip(df["phase"], df["runs_total"]))
+    df["phase_balls_tuple"] = list(zip(df["phase"], df["valid_ball"]))
 
     def _phase_sum(values):
         store: Dict[str, float] = {}
@@ -190,13 +241,13 @@ def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
         df.groupby(batter_group_cols)
         .agg(
             runs_scored=("runs_batter", "sum"),
-            balls_faced=("runs_batter", "count"),
+            balls_faced=("valid_ball", "sum"),
             fours=("is_four", "sum"),
             sixes=("is_six", "sum"),
             boundaries=("is_boundary", "sum"),
-            dot_balls=("is_dot_ball", "sum"),
+            dot_balls=("dot_ball_flag", "sum"),
             dismissals=("batter_dismissed", "sum"),
-            phases=("phase_runs_tuple", lambda s: _phase_sum([(phase, 1) for phase, _ in s] if len(s) else [])),
+            phases=("phase_runs_tuple", _phase_sum),
         )
         .reset_index()
     )
@@ -207,11 +258,11 @@ def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
         df.groupby(bowler_group_cols)
         .agg(
             runs_conceded=("runs_total", "sum"),
-            balls_bowled=("runs_total", "count"),
+            balls_bowled=("valid_ball", "sum"),
             wickets=("is_bowler_wicket", "sum"),
-            dot_balls_bowling=("is_dot_ball", "sum"),
+            dot_balls_bowling=("dot_ball_flag", "sum"),
             phase_runs=("phase_runs_tuple", _phase_sum),
-            phase_balls=("phase_balls_tuple", lambda s: _phase_sum([(phase, 1) for phase, _ in s] if len(s) else [])),
+            phase_balls=("phase_balls_tuple", _phase_sum),
         )
         .reset_index()
     )
@@ -219,7 +270,7 @@ def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
     if "phase" in df.columns:
         phase_stats = (
             df.groupby(["bowler", "phase"])
-            .agg(phase_runs=("runs_total", "sum"), phase_balls=("runs_total", "count"))
+            .agg(phase_runs=("runs_total", "sum"), phase_balls=("valid_ball", "sum"))
             .reset_index()
         )
     else:
@@ -229,9 +280,12 @@ def aggregate_player_match_stats(df: pd.DataFrame) -> pd.DataFrame:
 
     player_stats = pd.merge(batting_agg, bowling_agg, on=["match_id", "season", "team", "player"], how="outer", indicator=True)
 
-    for tmp_col in ["phase_runs_tuple_x", "phase_runs_tuple_y", "phase_balls_tuple"]:
+    for tmp_col in ["phase_runs_tuple_x", "phase_runs_tuple_y", "phase_balls_tuple", "dot_ball_flag_x", "dot_ball_flag_y"]:
         if tmp_col in player_stats.columns:
             player_stats = player_stats.drop(columns=tmp_col)
+
+    if "dot_ball_flag" in player_stats.columns:
+        player_stats = player_stats.drop(columns=["dot_ball_flag"])
 
     win_col = _select_first_available(df, COLUMN_ALIASES["win_team"], None)
     if win_col:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,365 @@
+"""Streamlit dashboard for IPL player impact insights."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, Tuple
+
+import altair as alt
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from clustering_roles import (
+    cluster_batters,
+    cluster_bowlers,
+    label_batter_clusters,
+    label_bowler_clusters,
+)
+from data_preprocessing import (
+    PreprocessingConfig,
+    aggregate_player_match_stats,
+    load_data,
+    prepare_ball_by_ball,
+)
+from feature_engineering import (
+    aggregate_player_ratings,
+    build_model_matrix,
+    compute_batting_metrics,
+    compute_bowling_metrics,
+    compute_composite_indices,
+)
+from model_training import train_impact_model
+from shap_analysis import compute_shap_values, summarise_shap_importance
+from team_selection import determine_primary_role, select_best_xi
+
+
+st.set_page_config(
+    page_title="IPL Impact Intelligence Dashboard",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+DATA_PATH = "IPL.csv"
+
+@lru_cache(maxsize=1)
+def _prepare_pipeline_outputs(path: str) -> Dict[str, object]:
+    raw_df = load_data(path)
+    processed_df = prepare_ball_by_ball(raw_df, PreprocessingConfig())
+
+    player_stats, phase_stats = aggregate_player_match_stats(processed_df)
+
+    batting_metrics = compute_batting_metrics(player_stats)
+    bowling_metrics = compute_bowling_metrics(player_stats, phase_stats)
+
+    features, metric_columns = compute_composite_indices(batting_metrics, bowling_metrics)
+    model_df, feature_cols = build_model_matrix(features, metric_columns)
+
+    artifacts = train_impact_model(model_df, feature_cols)
+
+    shap_frame, _ = compute_shap_values(artifacts.model, artifacts.X_train[feature_cols])
+    shap_summary = summarise_shap_importance(shap_frame)
+
+    shap_weights = dict(zip(shap_summary["feature"], shap_summary["mean_abs_shap"]))
+    if not shap_weights:
+        shap_weights = {column: 1.0 for column in feature_cols}
+
+    player_ratings = aggregate_player_ratings(model_df, shap_weights)
+
+    batter_base = batting_metrics[[
+        "player",
+        "team",
+        "balls_faced",
+        "batting_strike_rate",
+        "batting_average",
+        "boundary_percentage",
+        "dot_percentage",
+        "batting_index",
+    ]]
+    bowler_base = bowling_metrics[[
+        "player",
+        "team",
+        "balls_bowled",
+        "bowling_economy",
+        "bowling_strike_rate",
+        "wickets_per_match",
+        "phase_efficacy",
+        "bowling_index",
+    ]]
+
+    batter_clustered, batter_result = cluster_batters(batter_base)
+    bowler_clustered, bowler_result = cluster_bowlers(bowler_base)
+
+    batter_labels = label_batter_clusters(batter_result)
+    bowler_labels = label_bowler_clusters(bowler_result)
+
+    batter_mode = (
+        batter_clustered.groupby("player")["batter_cluster"]
+        .agg(lambda series: series.mode().iloc[0] if not series.mode().empty else series.iloc[0])
+    )
+    bowler_mode = (
+        bowler_clustered.groupby("player")["bowler_cluster"]
+        .agg(lambda series: series.mode().iloc[0] if not series.mode().empty else series.iloc[0])
+    )
+
+    volume_stats = (
+        features[["player", "balls_faced", "balls_bowled"]]
+        .fillna(0)
+        .groupby("player", as_index=False)
+        .sum()
+    )
+
+    player_profiles = (
+        player_ratings.merge(volume_stats, on="player", how="left")
+        .merge(batter_mode.rename("batter_cluster"), on="player", how="left")
+        .merge(bowler_mode.rename("bowler_cluster"), on="player", how="left")
+    )
+
+    player_profiles["balls_faced"] = player_profiles["balls_faced"].fillna(0)
+    player_profiles["balls_bowled"] = player_profiles["balls_bowled"].fillna(0)
+
+    player_profiles = (
+        player_profiles.sort_values("impact_rating", ascending=False)
+        .drop_duplicates(["player", "season", "team"], keep="first")
+        .reset_index(drop=True)
+    )
+
+    player_profiles["batter_role"] = player_profiles["batter_cluster"].map(batter_labels)
+    player_profiles["bowler_role"] = player_profiles["bowler_cluster"].map(bowler_labels)
+
+    player_profiles["primary_role"] = player_profiles.apply(
+        determine_primary_role,
+        axis=1,
+        batting_roles=batter_labels,
+        bowling_roles=bowler_labels,
+    )
+
+    best_xi = select_best_xi(player_profiles)
+
+    phase_summary = (
+        phase_stats.groupby("phase")
+        .agg(total_runs=("phase_runs", "sum"), total_balls=("phase_balls", "sum"))
+        .reset_index()
+    )
+    phase_summary["run_rate"] = np.where(
+        phase_summary["total_balls"] > 0,
+        (phase_summary["total_runs"] * 6) / phase_summary["total_balls"],
+        0.0,
+    )
+
+    bowler_phase = (
+        phase_stats.groupby(["bowler", "phase"])
+        .agg(phase_runs=("phase_runs", "sum"), phase_balls=("phase_balls", "sum"))
+        .reset_index()
+    )
+    bowler_phase["economy"] = np.where(
+        bowler_phase["phase_balls"] > 0,
+        (bowler_phase["phase_runs"] * 6) / bowler_phase["phase_balls"],
+        np.nan,
+    )
+
+    return {
+        "raw_df": raw_df,
+        "processed_df": processed_df,
+        "player_profiles": player_profiles,
+        "best_xi": best_xi,
+        "shap_summary": shap_summary,
+        "artifacts": artifacts,
+        "batter_clusters": batter_clustered,
+        "bowler_clusters": bowler_clustered,
+        "batter_labels": batter_labels,
+        "bowler_labels": bowler_labels,
+        "phase_summary": phase_summary,
+        "bowler_phase": bowler_phase,
+    }
+
+
+def _filter_profiles(
+    profiles: pd.DataFrame,
+    seasons: Tuple[str, ...],
+    teams: Tuple[str, ...],
+    min_balls: int,
+) -> pd.DataFrame:
+    filtered = profiles.copy()
+    if seasons:
+        filtered = filtered[filtered["season"].astype(str).isin(seasons)]
+    if teams:
+        filtered = filtered[filtered["team"].isin(teams)]
+    if min_balls:
+        workload = filtered[["balls_faced", "balls_bowled"]].fillna(0).sum(axis=1)
+        filtered = filtered[workload >= min_balls]
+    return filtered
+
+
+def _render_dataset_overview(raw_df: pd.DataFrame) -> None:
+    total_matches = raw_df["match_id"].nunique()
+    total_seasons = raw_df["season"].nunique()
+    total_teams = raw_df["batting_team"].nunique()
+
+    st.subheader("Dataset at a glance")
+    cols = st.columns(4)
+    cols[0].metric("Deliveries", f"{len(raw_df):,}")
+    cols[1].metric("Matches", f"{total_matches:,}")
+    cols[2].metric("Seasons", total_seasons)
+    cols[3].metric("Teams", total_teams)
+
+    st.dataframe(raw_df.head(100))
+
+
+def _render_model_performance(outputs: Dict[str, object]) -> None:
+    st.subheader("Model diagnostics")
+    artifacts = outputs["artifacts"]
+
+    metric_cols = st.columns(len(artifacts.metrics)) if artifacts.metrics else []
+    for idx, (metric, value) in enumerate(artifacts.metrics.items()):
+        metric_cols[idx].metric(metric.upper(), f"{value:.3f}")
+
+    shap_summary = outputs["shap_summary"]
+    top_features = shap_summary.head(10)
+
+    shap_chart = (
+        alt.Chart(top_features)
+        .mark_bar(color="#F97316")
+        .encode(
+            x=alt.X("mean_abs_shap:Q", title="Mean |SHAP|"),
+            y=alt.Y("feature:N", sort="-x", title="Feature"),
+            tooltip=["feature", alt.Tooltip("mean_abs_shap", format=".4f")],
+        )
+        .properties(height=320)
+    )
+    st.altair_chart(shap_chart, use_container_width=True)
+
+
+def _render_player_insights(filtered_profiles: pd.DataFrame, best_xi: pd.DataFrame) -> None:
+    st.subheader("Player impact leaders")
+    top_players = filtered_profiles.sort_values("impact_rating", ascending=False).head(15)
+
+    chart = (
+        alt.Chart(top_players)
+        .mark_bar()
+        .encode(
+            x=alt.X("impact_rating:Q", title="Impact rating"),
+            y=alt.Y("player:N", sort="-x"),
+            color=alt.Color("primary_role:N", legend=alt.Legend(title="Primary role")),
+            tooltip=["player", "team", "season", alt.Tooltip("impact_rating", format=".1f"), "primary_role"],
+        )
+        .properties(height=420)
+    )
+    st.altair_chart(chart, use_container_width=True)
+
+    role_breakdown = (
+        filtered_profiles.groupby("primary_role")["impact_rating"].mean().reset_index().sort_values("impact_rating")
+    )
+    st.markdown("**Average impact by role**")
+    role_chart = (
+        alt.Chart(role_breakdown)
+        .mark_circle(size=180, color="#10B981")
+        .encode(
+            x=alt.X("impact_rating:Q", title="Average rating"),
+            y=alt.Y("primary_role:N", sort="-x"),
+            tooltip=["primary_role", alt.Tooltip("impact_rating", format=".1f")],
+        )
+        .properties(height=260)
+    )
+    st.altair_chart(role_chart, use_container_width=True)
+
+    st.markdown("**Suggested Best XI**")
+    st.dataframe(best_xi[["player", "team", "impact_rating", "primary_role", "balls_faced", "balls_bowled"]])
+
+
+def _render_team_and_phase_insights(filtered_profiles: pd.DataFrame, outputs: Dict[str, object]) -> None:
+    st.subheader("Team and phase insights")
+
+    team_summary = (
+        filtered_profiles.groupby("team")["impact_rating"].mean().reset_index().sort_values("impact_rating", ascending=False)
+    )
+    team_chart = (
+        alt.Chart(team_summary)
+        .mark_bar(color="#2563EB")
+        .encode(
+            x=alt.X("impact_rating:Q", title="Avg impact rating"),
+            y=alt.Y("team:N", sort="-x"),
+            tooltip=["team", alt.Tooltip("impact_rating", format=".1f")],
+        )
+        .properties(height=360)
+    )
+
+    season_summary = (
+        filtered_profiles.groupby("season")["impact_rating"].mean().reset_index().sort_values("season")
+    )
+    season_chart = (
+        alt.Chart(season_summary)
+        .mark_line(point=True, color="#7C3AED")
+        .encode(
+            x=alt.X("season:N", title="Season"),
+            y=alt.Y("impact_rating:Q", title="Avg impact rating"),
+            tooltip=["season", alt.Tooltip("impact_rating", format=".2f")],
+        )
+        .properties(height=360)
+    )
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.altair_chart(team_chart, use_container_width=True)
+    with col2:
+        st.altair_chart(season_chart, use_container_width=True)
+
+    phase_summary = outputs["phase_summary"]
+    phase_chart = (
+        alt.Chart(phase_summary)
+        .mark_bar(color="#F59E0B")
+        .encode(
+            x=alt.X("phase:N", title="Phase"),
+            y=alt.Y("run_rate:Q", title="League run rate"),
+            tooltip=["phase", alt.Tooltip("run_rate", format=".2f")],
+        )
+        .properties(height=320)
+    )
+
+    bowler_phase = outputs["bowler_phase"]
+    death_specialists = (
+        bowler_phase[bowler_phase["phase"] == "Death"]
+        .dropna(subset=["economy"])
+        .sort_values("economy")
+        .head(10)
+    )
+
+    col3, col4 = st.columns(2)
+    with col3:
+        st.markdown("**League scoring rate by phase**")
+        st.altair_chart(phase_chart, use_container_width=True)
+    with col4:
+        st.markdown("**Top 10 death-over economies**")
+        st.dataframe(
+            death_specialists[["bowler", "economy", "phase_runs", "phase_balls"]]
+            .rename(columns={"bowler": "player"})
+            .assign(economy=lambda df: df["economy"].round(2))
+        )
+
+
+def main() -> None:
+    outputs = _prepare_pipeline_outputs(DATA_PATH)
+    raw_df = outputs["raw_df"]
+    player_profiles = outputs["player_profiles"]
+
+    seasons = tuple(sorted(player_profiles["season"].dropna().astype(str).unique()))
+    teams = tuple(sorted(player_profiles["team"].dropna().unique()))
+
+    st.sidebar.header("Filters")
+    selected_seasons = st.sidebar.multiselect("Seasons", seasons, default=seasons[-3:] if len(seasons) > 3 else seasons)
+    selected_teams = st.sidebar.multiselect("Teams", teams, default=teams)
+    min_balls = st.sidebar.slider("Minimum combined balls faced/bowled", 0, int(player_profiles[["balls_faced", "balls_bowled"]].sum(axis=1).max()), 60, step=10)
+
+    filtered_profiles = _filter_profiles(player_profiles, tuple(selected_seasons), tuple(selected_teams), min_balls)
+
+    st.title("IPL Impact Intelligence Dashboard")
+    st.caption("Trained on the Kaggle IPL ball-by-ball dataset to surface player roles and match impact.")
+
+    _render_dataset_overview(raw_df)
+    _render_model_performance(outputs)
+    _render_player_insights(filtered_profiles, outputs["best_xi"])
+    _render_team_and_phase_insights(filtered_profiles, outputs)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/team_selection.py
+++ b/team_selection.py
@@ -1,0 +1,72 @@
+"""Team selection and role assignment helpers for the IPL impact project."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+
+def determine_primary_role(
+    row: pd.Series,
+    batting_roles: Dict[int, str],
+    bowling_roles: Dict[int, str],
+) -> str:
+    """Infer a player's headline role by combining batting and bowling signals."""
+
+    has_batting = row.get("balls_faced", 0) > 30
+    has_bowling = row.get("balls_bowled", 0) > 18
+
+    batter_cluster = row.get("batter_cluster")
+    bowler_cluster = row.get("bowler_cluster")
+
+    batter_label = batting_roles.get(batter_cluster) if batter_cluster is not None else None
+    bowler_label = bowling_roles.get(bowler_cluster) if bowler_cluster is not None else None
+
+    if has_batting and has_bowling:
+        return "Allrounder"
+    if has_batting and batter_label:
+        return batter_label
+    if has_bowling and bowler_label:
+        return bowler_label
+    return batter_label or bowler_label or "Specialist"
+
+
+def select_best_xi(player_profiles: pd.DataFrame) -> pd.DataFrame:
+    """Select a balanced Best XI using impact ratings and role coverage."""
+
+    selected_players: List[str] = []
+
+    def _select_players(df: pd.DataFrame, count: int) -> List[str]:
+        chosen: List[str] = []
+        for _, candidate in df.sort_values("impact_rating", ascending=False).iterrows():
+            name = candidate["player"]
+            if name in selected_players:
+                continue
+            selected_players.append(name)
+            chosen.append(name)
+            if len(chosen) == count:
+                break
+        return chosen
+
+    batting_roles = {"Power Hitter", "Anchor", "Accumulator", "Finisher"}
+    bowling_roles = {"Death Specialist", "Strike Bowler", "Powerplay Controller", "Middle Overs"}
+
+    batters = player_profiles[player_profiles["primary_role"].isin(batting_roles)]
+    _select_players(batters, min(5, len(batters)))
+
+    allrounders = player_profiles[player_profiles["primary_role"] == "Allrounder"]
+    _select_players(allrounders, min(2, len(allrounders)))
+
+    bowlers = player_profiles[player_profiles["primary_role"].isin(bowling_roles)]
+    _select_players(bowlers, 11 - len(selected_players))
+
+    if len(selected_players) < 11:
+        remaining = player_profiles[~player_profiles["player"].isin(selected_players)]
+        _select_players(remaining, 11 - len(selected_players))
+
+    return (
+        player_profiles[player_profiles["player"].isin(selected_players)]
+        .sort_values("impact_rating", ascending=False)
+        .reset_index(drop=True)
+    )
+


### PR DESCRIPTION
## Summary
- add a Streamlit dashboard that trains on IPL.csv and surfaces interactive player, team, and phase insights
- refactor role inference and XI selection helpers into a shared module for reuse across the CLI and UI
- wire the main pipeline to the shared helpers to keep behaviour consistent between interfaces

## Testing
- `python -m py_compile main.py streamlit_app.py team_selection.py`


------
https://chatgpt.com/codex/tasks/task_b_68e420439cd483238890327d4b104599